### PR TITLE
Bug fixes and Colab support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pb filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Abstract
 
 ## Demo on Google Colab
-[demo_inference.ipynb](http://colab.research.google.com/github/AISIN-TRC/E2Pose/blob/main/demo_inference.ipynb)
+[demo_inference.ipynb](http://colab.research.google.com/github/MasakazuTobeta/AisinE2Pose/blob/dev_init_colab/demo_inference.ipynb)
 
 ## Download pre-train models
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 ## Demo on Google Colab
 [demo_inference.ipynb](http://colab.research.google.com/github/AISIN-TRC/E2Pose/blob/main/demo_inference.ipynb)
 
+## Download pre-train models
+```bash
+./pretrains/download.sh
+```
 
 ## Inference E2Pose's demo on localhost
 ```bash

--- a/demo_inference.ipynb
+++ b/demo_inference.ipynb
@@ -57,9 +57,35 @@
     {
       "cell_type": "markdown",
       "source": [
+        "# **Upload movies or images**\n",
+        "\n",
+        "Upload the videos or images you want to multi-person pose estimation."
+      ],
+      "metadata": {
+        "id": "IjN8D5S2XxdZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import files\n",
+        "import shutil\n",
+        "import os\n",
+        "for fn in files.upload().keys():\n",
+        "  shutil.move(fn, os.path.join('/content/Inputs',fn))"
+      ],
+      "metadata": {
+        "id": "b3ob7rXqYIco"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
         "# **Inference**\n",
         "\n",
-        "Store the videos and/or photos you have in the /content/Inputs directory. After that, run the script below and the result will be stored in the /content/Outputs directory."
+        "Perform the inference."
       ],
       "metadata": {
         "id": "PPv-gDDYkh4y"
@@ -75,6 +101,165 @@
       "metadata": {
         "id": "kerlIB88xMsB"
       }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# **Download movies or images**\n",
+        "\n",
+        "Save the inference results to the local machine."
+      ],
+      "metadata": {
+        "id": "Vtl3GSTyakTx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import files\n",
+        "import glob\n",
+        "for dst in glob.glob('/content/Outputs/*'):\n",
+        "  files.download(dst)"
+      ],
+      "metadata": {
+        "id": "P4158vPDayMH",
+        "outputId": "147b0669-5fa2-47af-ef48-e4ae7b060f6c",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 17
+        }
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/javascript": [
+              "\n",
+              "    async function download(id, filename, size) {\n",
+              "      if (!google.colab.kernel.accessAllowed) {\n",
+              "        return;\n",
+              "      }\n",
+              "      const div = document.createElement('div');\n",
+              "      const label = document.createElement('label');\n",
+              "      label.textContent = `Downloading \"${filename}\": `;\n",
+              "      div.appendChild(label);\n",
+              "      const progress = document.createElement('progress');\n",
+              "      progress.max = size;\n",
+              "      div.appendChild(progress);\n",
+              "      document.body.appendChild(div);\n",
+              "\n",
+              "      const buffers = [];\n",
+              "      let downloaded = 0;\n",
+              "\n",
+              "      const channel = await google.colab.kernel.comms.open(id);\n",
+              "      // Send a message to notify the kernel that we're ready.\n",
+              "      channel.send({})\n",
+              "\n",
+              "      for await (const message of channel.messages) {\n",
+              "        // Send a message to notify the kernel that we're ready.\n",
+              "        channel.send({})\n",
+              "        if (message.buffers) {\n",
+              "          for (const buffer of message.buffers) {\n",
+              "            buffers.push(buffer);\n",
+              "            downloaded += buffer.byteLength;\n",
+              "            progress.value = downloaded;\n",
+              "          }\n",
+              "        }\n",
+              "      }\n",
+              "      const blob = new Blob(buffers, {type: 'application/binary'});\n",
+              "      const a = document.createElement('a');\n",
+              "      a.href = window.URL.createObjectURL(blob);\n",
+              "      a.download = filename;\n",
+              "      div.appendChild(a);\n",
+              "      a.click();\n",
+              "      div.remove();\n",
+              "    }\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/javascript": [
+              "download(\"download_66cd0505-006d-4c57-b9a7-aeb7115a7153\", \"100000.jpg\", 133005)"
+            ],
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/javascript": [
+              "\n",
+              "    async function download(id, filename, size) {\n",
+              "      if (!google.colab.kernel.accessAllowed) {\n",
+              "        return;\n",
+              "      }\n",
+              "      const div = document.createElement('div');\n",
+              "      const label = document.createElement('label');\n",
+              "      label.textContent = `Downloading \"${filename}\": `;\n",
+              "      div.appendChild(label);\n",
+              "      const progress = document.createElement('progress');\n",
+              "      progress.max = size;\n",
+              "      div.appendChild(progress);\n",
+              "      document.body.appendChild(div);\n",
+              "\n",
+              "      const buffers = [];\n",
+              "      let downloaded = 0;\n",
+              "\n",
+              "      const channel = await google.colab.kernel.comms.open(id);\n",
+              "      // Send a message to notify the kernel that we're ready.\n",
+              "      channel.send({})\n",
+              "\n",
+              "      for await (const message of channel.messages) {\n",
+              "        // Send a message to notify the kernel that we're ready.\n",
+              "        channel.send({})\n",
+              "        if (message.buffers) {\n",
+              "          for (const buffer of message.buffers) {\n",
+              "            buffers.push(buffer);\n",
+              "            downloaded += buffer.byteLength;\n",
+              "            progress.value = downloaded;\n",
+              "          }\n",
+              "        }\n",
+              "      }\n",
+              "      const blob = new Blob(buffers, {type: 'application/binary'});\n",
+              "      const a = document.createElement('a');\n",
+              "      a.href = window.URL.createObjectURL(blob);\n",
+              "      a.download = filename;\n",
+              "      div.appendChild(a);\n",
+              "      a.click();\n",
+              "      div.remove();\n",
+              "    }\n",
+              "  "
+            ],
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/javascript": [
+              "download(\"download_73954a67-2213-4eb3-a86f-d528609e8144\", \"100001.jpg\", 134138)"
+            ],
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
     }
   ]
 }

--- a/demo_inference.ipynb
+++ b/demo_inference.ipynb
@@ -1,6 +1,6 @@
 {
   "nbformat": 4,
-  "nbformat_minor": 2,
+  "nbformat_minor": 0,
   "metadata": {
     "colab": {
       "name": "demo_inference.ipynb",
@@ -32,7 +32,7 @@
       "source": [
         "# **Setup**\n",
         "\n",
-        "Clone repo, install dependencies, %cd into E2Pose folder and check GPU."
+        "Check the GPU, clone the repository, and download the pre-train model."
       ],
       "metadata": {
         "id": "WXbNROLIgxEi"
@@ -42,39 +42,16 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "import os\r\n",
-        "import re\r\n",
-        "from IPython.display import clear_output\r\n",
-        "import tensorflow as tf\r\n",
-        "from tensorflow.python.client import device_lib\r\n",
-        "\r\n",
-        "!git clone https://github.com/AISIN-TRC/E2Pose.git\r\n",
-        "if not os.path.isdir('/content/E2Pose'):\r\n",
-        "  from google import colab\r\n",
-        "  colab.drive.mount('/content/gdrive')\r\n",
-        "  !cp /content/gdrive/MyDrive/E2Pose/E2Pose.zip /content/\r\n",
-        "  !cd /content && unzip /content/E2Pose.zip\r\n",
-        "\r\n",
-        "%cd /content/E2Pose\r\n",
-        "print('GPU device name: ', [re.findall('name: [^,]+', x.physical_device_desc)[0].replace('name: ', '') for x in device_lib.list_local_devices() if x.device_type == 'GPU'][0])"
+        "!nvidia-smi\n",
+        "!mkdir /content/Inputs\n",
+        "!mkdir /content/Outputs\n",
+        "!git clone -b dev_init_colab https://github.com/MasakazuTobeta/AisinE2Pose.git ./E2Pose\n",
+        "%cd /content/E2Pose\n",
+        "!./pretrains/download.sh"
       ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "fatal: destination path 'E2Pose' already exists and is not an empty directory.\n",
-            "/content/E2Pose\n",
-            "GPU device name:  Tesla T4\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "pq_NRX_6LXGQ",
-        "outputId": "4243ceef-1412-42cb-8206-20289abb2727"
+        "id": "F8V1INLhreH6"
       }
     },
     {
@@ -82,7 +59,7 @@
       "source": [
         "# **Inference**\n",
         "\n",
-        "Store the videos and photos you have in the E2Pose/sample directory. After that, run the script below and the result will be stored in the E2Pose/sample_out/e2pose directory."
+        "Store the videos and/or photos you have in the /content/Inputs directory. After that, run the script below and the result will be stored in the /content/Outputs directory."
       ],
       "metadata": {
         "id": "PPv-gDDYkh4y"
@@ -92,26 +69,11 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "!python ./inference.py --src './sample/*' --dst ./sample_out/e2pose --add_fps True --add_blur False --model ./pretrains/COCO/ResNet101/512x512/saved_model"
+        "!python3 ./inference.py --src '/content/Inputs/*' --dst /content/Outputs --model ./pretrains/COCO/ResNet101/512x512/frozen_model.pb"
       ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Namespace(add_blur=False, add_fps=True, backbone='ResNet50', dataset='COCO', dev=False, dst=PosixPath('sample_out/e2pose'), model=PosixPath('pretrains/COCO/ResNet101/512x512/saved_model'), src=['./sample/IMG_0456.mp4'], tftrt=False)\n",
-            "2022-02-13 01:01:27.574303: W tensorflow/core/common_runtime/gpu/gpu_bfc_allocator.cc:39] Overriding allow_growth setting because the TF_FORCE_GPU_ALLOW_GROWTH environment variable is set. Original config value was 0.\n",
-            "1162it [01:04, 18.04it/s]\n",
-            "sample_out/e2pose/IMG_0456.mp4.mp4: 100%|██████████████████████████████████████████| 1162/1162 [00:10<00:00, 112.80it/s]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "kerlIB88xMsB",
-        "outputId": "4c45ee62-bba9-49ad-80ab-a389ccc5e564"
+        "id": "kerlIB88xMsB"
       }
     }
   ]

--- a/demo_inference.ipynb
+++ b/demo_inference.ipynb
@@ -59,7 +59,8 @@
       "source": [
         "# **Upload movies or images**\n",
         "\n",
-        "Upload the videos or images you want to multi-person pose estimation."
+        "Upload the videos or images you want to multi-person pose estimation.\n",
+        "If the file size is too large and upload fails, store the file directly into the Inputs folder from the file browser."
       ],
       "metadata": {
         "id": "IjN8D5S2XxdZ"
@@ -129,7 +130,7 @@
           "height": 17
         }
       },
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",

--- a/pretrains/COCO/ResNet101/512x512/frozen_model.pb
+++ b/pretrains/COCO/ResNet101/512x512/frozen_model.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d2b04917d69ab8f6ac1a8b49aba90a5ffdf9078d19e59c9aac1efffda1e6d7d
-size 190311190

--- a/pretrains/download.sh
+++ b/pretrains/download.sh
@@ -1,0 +1,1 @@
+wget -v -O $(dirname $0)/COCO/ResNet101/512x512/frozen_model.pb -L https://www.dropbox.com/s/ewvbnr85riym2l7/e2pose_coco_resnet101_512.pb?dl=1


### PR DESCRIPTION
## Summary
* Changed the location of the trained models.
* Fixed Google Colab notebook

## Details
* Saving trained models to Git LFS is not a good idea, as it limits the donwload bandwidth and many people fail to clone. Save the mirror file to my Dropbox and use download.sh to save it.
* Google Colab has a different Python version from the Docker container, which causes errors when loading models. We fixed the error by using the trained model as a proto-buffer.

## Remarks
The Google Colab hyperlink in README.md needs to be changed appropriately.
Similarly, the git clone URL at the beginning of demo_inference.ipynb should be modified appropriately.